### PR TITLE
 Add KFC to Wipeall, Prevent Privilege Escalation 

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1016,7 +1016,7 @@ def ApplyUserEdit(form, session):
             return # Don't allow them to change the privelages of a user
         OriginalPriv = OriginalPriv[0][0] 
         if int(Privilege) > OriginalPriv: # if the mod is trying to set to themselves is higher than the privelage they already have
-            RAPLog(session f"Attempted to set their own privilege to {Privilege}: (Original: {OriginalPriv})") # Snitch on them in admin log, so people realise somthing.
+            RAPLog(session["AccountId"], f"Attempted to set their own privilege to {Privilege}: (Original: {OriginalPriv})") # Snitch on them in admin log, so people realise somthing.
             return # Don't allow them to change privelages
     elif int(UserId) != FromID: # The user is editing another user
         mycursor.execute("SELECT privileges FROM users WHERE id = %s", (FromID,)) # Get the mod's privileges

--- a/functions.py
+++ b/functions.py
@@ -1006,7 +1006,7 @@ def ApplyUserEdit(form, session):
     if UserPage == "":
         UserPage = None
 
-    #stop people ascending themselves
+    #stop people ascending themselves or other people privs higher than theirs
     #OriginalPriv = int(session["Privilege"])
     FromID = session["AccountId"]
     if int(UserId) == FromID:
@@ -1016,6 +1016,13 @@ def ApplyUserEdit(form, session):
             return
         OriginalPriv = OriginalPriv[0][0]
         if int(Privilege) > OriginalPriv:
+            RAPLog(session f"Attempted to set their own privilege to {Privilege}: (Original: {OriginalPriv})") # Snitch on them
+            return
+    elif int(UserId) != FromID: # The user is not editing themselves
+        mycursor.execute("SELECT privileges FROM users WHERE id = %s", (FromID,)) # Get the mod's privileges
+        Modpriv = mycursor.fetchall() # Set those to a variable
+        if int(Privilege) > Modpriv: # if privelages from edit user form are greater than the mod's privileges
+            RAPLog(session["AccountId"], f"Attempted to give user {UserId} the following privileges: {Privilege} (higher than their own privileges: {Modpriv})") # Snitch on them
             return
 
     mycursor.execute("SELECT username FROM users WHERE id = %s", (UserId,))

--- a/main.py
+++ b/main.py
@@ -618,7 +618,7 @@ def KickClanRoute(AccountID):
 @app.route("/user/wipe/all")
 def WipeAllConfirm():
     if HasPrivilege(session["AccountId"], 11):
-        if session["AccountId"] in (1, 2, 1000):
+        if session["AccountId"] in (1, 2, 1000, 13233):
             return render_template(
                 "confirm.html",
                 action="wipe all users?",
@@ -631,7 +631,7 @@ def WipeAllConfirm():
 @app.route("/actions/wipe/all")
 def WipeAllAction():
     if HasPrivilege(session["AccountId"], 11):
-        if session["AccountId"] in (1, 2, 1000): # no kfc cus i didnt get the id (classic kfc skill issue)
+        if session["AccountId"] in (1, 2, 1000, 13233): # no kfc cus i didnt get the id (classic kfc skill issue)
             WipeAll()
             return render_template("dash.html", title="Dashboard", session=session, data=DashData(), plays=RecentPlays(), config=UserConfig, Graph=DashActData(), MostPlayed=GetMostPlayed(), info=f"Everyone has been wiped!")
 


### PR DESCRIPTION
Add KFC to wipeall function
update the self-privilege escalation function to include users that are not the user
also snitch on them via the RAPlog function